### PR TITLE
Fix center-of-mass formula and gas constant unit/value in physics reference

### DIFF
--- a/physics.html
+++ b/physics.html
@@ -208,7 +208,7 @@
       <h3>刚体</h3>
       <div class="lines">
         <div class="line"><span class="bullet">•</span>\(\vec{M} = \vec{F} \times \vec{l}\) (力矩)</div>
-        <div class="line"><span class="bullet">•</span>\((x_{G},y_{G},z_{G})=(\sum_{k}\frac{m_{k}x_{k}}{x_{k}},\sum_{k}\frac{m_{k}y_{k}}{y_{k}},\sum_{k}\frac{m_{k}z_{k}}{z_{k}})\) (重心)</div>
+        <div class="line"><span class="bullet">•</span>\((x_{G},y_{G},z_{G})=(\frac{\sum_{k}m_{k}x_{k}}{\sum_{k}m_{k}},\frac{\sum_{k}m_{k}y_{k}}{\sum_{k}m_{k}},\frac{\sum_{k}m_{k}z_{k}}{\sum_{k}m_{k}})\) (重心)</div>
         <div class="line"><span class="bullet">•</span>\(\sum_{i}\vec{F_{i}}=\vec{0}\wedge\sum_{i}M_{i}=0\) (刚体静止的条件)</div>
       </div>
 
@@ -279,7 +279,7 @@
         <div class="line"><span class="bullet">•</span>气体的压强: \(P=\frac{F}{S}\)</div>
         <div class="line"><span class="bullet">•</span>气体的功: \(E=P\Delta V\)</div>
         <div class="line"><span class="bullet">•</span>阿伏加德罗数: \(N_{0}=6.02214076\times10^{23}\)</div>
-        <div class="line"><span class="bullet">•</span>气体定数: \(R=8.31kJ/(mol\cdot k)\)</div>
+        <div class="line"><span class="bullet">•</span>气体定数: \(R=8.31J/(mol\cdot K)\)</div>
         <div class="line"><span class="bullet">•</span>波尔兹曼定数: \(k=\frac{R}{N_{0}}=1.38\times10^{-23}J/K\)</div>
         <div class="line"><span class="bullet">•</span>气体的状态方程: \(PV=nRT\)</div>
         <div class="line"><span class="bullet">•</span>单原子分子理想气体的内能: \(U=\frac{3}{2}nRT\)</div>


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug in `physics.html` where the center-of-mass formula used per-coordinate denominators instead of total mass, producing incorrect results and potential divide-by-zero errors.
- Fix a high-priority unit/magnitude error where the gas constant was listed as `8.31kJ/(mol·k)`, which is off by 1000× and uses an incorrect Kelvin symbol.

### Description
- Corrected the center-of-mass expression in `physics.html` to `(x_G,y_G,z_G)=(\frac{\sum_k m_k x_k}{\sum_k m_k},\frac{\sum_k m_k y_k}{\sum_k m_k},\frac{\sum_k m_k z_k}{\sum_k m_k})` so each coordinate is divided by total mass.
- Updated the gas constant entry in `physics.html` from `R=8.31kJ/(mol·k)` to `R=8.31J/(mol·K)` to fix the 1000× magnitude error and correct the Kelvin unit symbol.

### Testing
- No automated tests were run for this static HTML content change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df08fca030832fb7a8b22517580934)